### PR TITLE
[DM-23433] Bump version for 0.1.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Change log
 ##########
 
-0.1.0 (unreleased)
+0.1.0 (2020-02-13)
 ==================
 
 - userve-ghslacker can now be deployed through Kustomize.

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN        useradd -d /home/uwsgi -m uwsgi
 RUN        mkdir /dist
 
 # Must run python setup.py sdist first.
-ARG        VERSION="0.0.7"
+ARG        VERSION="0.1.0"
 LABEL      version="$VERSION"
 COPY       dist/sqre-uservice-ghslacker-$VERSION.tar.gz /dist
 RUN        pip install /dist/sqre-uservice-ghslacker-$VERSION.tar.gz

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: ghslacker
-          image: lsstsqre/uservice-ghslacker
+          image: lsstsqre/uservice-ghslacker:0.1.0
           imagePullPolicy: Always
           ports:
             - containerPort: 5000

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ DESCRIPTION = 'Slack <-> GitHub user mapper'
 AUTHOR = 'Adam Thornton'
 AUTHOR_EMAIL = 'athornton@lsst.org'
 URL = 'https://github.com/sqre-lsst/uservice-ghslacker'
-VERSION = '0.0.7'
+VERSION = '0.1.0'
 LICENSE = 'MIT'
 
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     packages=find_packages(exclude=['docs', 'tests*']),
     install_requires=[
         'sqre-apikit==0.1.1',
-        'uWSGI==2.0.14',
+        'uWSGI==2.0.18',
         'requests-futures==0.9.7'
     ],
     tests_require=['pytest'],

--- a/uservice_ghslacker/server.py
+++ b/uservice_ghslacker/server.py
@@ -27,7 +27,7 @@ def server(run_standalone=False):
     """
     # Add "/ghslacker" for mapping behind api.lsst.codes
     app = APIFlask(name="uservice-ghslacker",
-                   version="0.0.7",
+                   version="0.1.0",
                    repository="https://github.com/sqre-lsst/uservice-ghslacker",
                    description="Slack <-> GitHub user mapper",
                    route=["/", "/ghslacker"],


### PR DESCRIPTION
- Bump version and pin Kustomize configuration to a specific Docker image
- Update uWSGI version for Python 3 and modern OpenSSL support