### PR TITLE
Bump dependency on sqre-apikit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Change log
 ##########
 
+0.1.1 (2020-02-14)
+==================
+
+- Bump dependency on sqre-apikit to pick up a fix for a conflict between older Flsk and new werkzeug.
+
 0.1.0 (2020-02-13)
 ==================
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN        useradd -d /home/uwsgi -m uwsgi
 RUN        mkdir /dist
 
 # Must run python setup.py sdist first.
-ARG        VERSION="0.1.0"
+ARG        VERSION="0.1.1"
 LABEL      version="$VERSION"
 COPY       dist/sqre-uservice-ghslacker-$VERSION.tar.gz /dist
 RUN        pip install /dist/sqre-uservice-ghslacker-$VERSION.tar.gz

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: ghslacker
-          image: lsstsqre/uservice-ghslacker:0.1.0
+          image: lsstsqre/uservice-ghslacker:0.1.1
           imagePullPolicy: Always
           ports:
             - containerPort: 5000

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ DESCRIPTION = 'Slack <-> GitHub user mapper'
 AUTHOR = 'Adam Thornton'
 AUTHOR_EMAIL = 'athornton@lsst.org'
 URL = 'https://github.com/sqre-lsst/uservice-ghslacker'
-VERSION = '0.1.0'
+VERSION = '0.1.1'
 LICENSE = 'MIT'
 
 
@@ -43,7 +43,7 @@ setup(
     keywords='lsst',
     packages=find_packages(exclude=['docs', 'tests*']),
     install_requires=[
-        'sqre-apikit==0.1.1',
+        'sqre-apikit==0.1.3',
         'uWSGI==2.0.18',
         'requests-futures==0.9.7'
     ],

--- a/uservice_ghslacker/server.py
+++ b/uservice_ghslacker/server.py
@@ -27,7 +27,7 @@ def server(run_standalone=False):
     """
     # Add "/ghslacker" for mapping behind api.lsst.codes
     app = APIFlask(name="uservice-ghslacker",
-                   version="0.1.0",
+                   version="0.1.1",
                    repository="https://github.com/sqre-lsst/uservice-ghslacker",
                    description="Slack <-> GitHub user mapper",
                    route=["/", "/ghslacker"],


### PR DESCRIPTION
Bump dependency on sqre-apikit to pick up a fix for a conflict between
older Flsk and new werkzeug.

Release as v0.1.1.